### PR TITLE
Only bootstrap Laravel env for Laravel specs

### DIFF
--- a/spec/PhpSpec/Laravel/Listener/LaravelListenerSpec.php
+++ b/spec/PhpSpec/Laravel/Listener/LaravelListenerSpec.php
@@ -6,6 +6,8 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use PhpSpec\Laravel\Util\Laravel;
 use PhpSpec\Event\SpecificationEvent;
+use PhpSpec\Loader\Node\SpecificationNode;
+use ReflectionClass;
 
 class LaravelListenerSpec extends ObjectBehavior
 {
@@ -19,8 +21,26 @@ class LaravelListenerSpec extends ObjectBehavior
         $this->shouldHaveType('Symfony\Component\EventDispatcher\EventSubscriberInterface');
     }
 
-    function it_refreshes_the_laravel_framework_before_spec_is_run(Laravel $laravel, SpecificationEvent $event)
+    function it_refreshes_the_laravel_framework_before_spec_is_run(Laravel $laravel,
+                                                                   SpecificationEvent $event,
+                                                                   SpecificationNode $spec,
+                                                                   ReflectionClass $refl)
     {
+        $event
+            ->getSpecification()
+            ->shouldBeCalled()
+            ->willReturn($spec);
+
+        $spec
+            ->getClassReflection()
+            ->shouldBeCalled()
+            ->willReturn($refl);
+
+        $refl
+            ->hasMethod('setLaravel')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
         $laravel->refreshApplication()->shouldBeCalled();
 
         $this->beforeSpecification($event);

--- a/spec/PhpSpec/Laravel/Util/LaravelSpec.php
+++ b/spec/PhpSpec/Laravel/Util/LaravelSpec.php
@@ -9,44 +9,53 @@ use Illuminate\Console\Application as Console;
 
 class LaravelSpec extends ObjectBehavior
 {
-    function let(Application $app)
+    private $appInst;
+
+    function let(Application $appInst)
     {
-        $app->setRequestForConsoleEnvironment()->shouldBeCalled();
-        $app->boot()->shouldBeCalled();
+        $this->appInst = $appInst;
     }
 
-    function it_boots_in_the_testing_env_by_default(Application $app)
+    function it_boots_in_the_testing_env_by_default()
     {
-        $this->beConstructedWith(null, '.', false, $app);
+        $this->beConstructedWith(null, '.', false);
         $this->getEnv()->shouldBe('testing');
     }
 
-    function it_allows_the_env_to_be_set_to_anything(Application $app)
+    function it_allows_the_env_to_be_set_to_anything()
     {
-        $this->beConstructedWith('whatever', '.', false, $app);
+        $this->beConstructedWith('whatever', '.', false);
         $this->getEnv()->shouldBe('whatever');
     }
 
-    function it_will_run_migrations_if_told_to(Application $app, Console $console)
+    function it_will_run_migrations_if_told_to(Console $console)
     {
         $console->call('migrate:install')->shouldBeCalled();
         $console->call('migrate:refresh')->shouldBeCalled();
-        $app->make('artisan')->shouldBeCalled();
-        $app->make('artisan')->willReturn($console);
 
-        $this->beConstructedWith(null, '.', true, $app);
+        $this->appInst->setRequestForConsoleEnvironment()->shouldBeCalled();
+        $this->appInst->boot()->shouldBeCalled();
+        $this->appInst->make('artisan')->shouldBeCalled();
+        $this->appInst->make('artisan')->willReturn($console);
+
+        $this->beConstructedWith(null, '.', true);
         $this->getMigrateDatabase()->shouldBe(true);
+        $this->refreshApplication($this->appInst);
     }
 
-    function it_allows_access_to_the_app(Application $app)
+    function it_allows_access_to_the_app()
     {
-        $this->beConstructedWith(null, '.', false, $app);
+        $this->appInst->setRequestForConsoleEnvironment()->shouldBeCalled();
+        $this->appInst->boot()->shouldBeCalled();
+
+        $this->beConstructedWith(null, '.', false);
+        $this->refreshApplication($this->appInst);
         $this->app->shouldHaveType('Illuminate\Foundation\Application');
     }
 
-    function it_throws_an_exception_when_trying_to_get_inaccessible_vars(Application $app)
+    function it_throws_an_exception_when_trying_to_get_inaccessible_vars()
     {
-        $this->beConstructedWith(null, '.', false, $app);
+        $this->beConstructedWith(null, '.', false);
         $this->shouldThrow('ErrorException')->during('__get', array('inaccessible'));
     }
 }

--- a/src/PhpSpec/Laravel/Listener/LaravelListener.php
+++ b/src/PhpSpec/Laravel/Listener/LaravelListener.php
@@ -7,6 +7,8 @@ use PhpSpec\Laravel\Util\Laravel;
 
 /**
  * This listener is used to setup the Laravel application for each spec.
+ *
+ * This only applies to specs that implement the LaravelBehaviorInterface.
  */
 class LaravelListener implements EventSubscriberInterface {
 
@@ -48,6 +50,10 @@ class LaravelListener implements EventSubscriberInterface {
      */
     public function beforeSpecification(SpecificationEvent $event)
     {
-        $this->laravel->refreshApplication();
+        $spec = $event->getSpecification();
+
+        if ($spec->getClassReflection()->hasMethod('setLaravel')) {
+            $this->laravel->refreshApplication();
+        }
     }
 }

--- a/src/PhpSpec/Laravel/Util/Laravel.php
+++ b/src/PhpSpec/Laravel/Util/Laravel.php
@@ -46,16 +46,13 @@ class Laravel {
      * @param string  $bootstrapPath   Path to the Laravel bootstrap dir
      * @param boolean $migrateDatabase Whether or not to run db migrations after
      *                                 bootstrapping. False by default
-     * @param mixed                    @see refreshApplication()
      * @return void
      */
-    public function __construct($env, $bootstrapPath, $migrateDatabase = false, $app = null)
+    public function __construct($env, $bootstrapPath, $migrateDatabase = false)
     {
         $this->env = $env ?: 'testing';
         $this->bootstrapPath = $bootstrapPath;
         $this->migrateDatabase = $migrateDatabase;
-
-        $this->refreshApplication($app);
     }
 
     /**


### PR DESCRIPTION
This PR ensures that the Laravel environment is only bootstrapped for specs that require it.

Closes #5.
