### PR TITLE
Set Laravel path in phpspec.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ specify the path to the Laravel framework files like so:
 
 ```yaml
 laravel_extension:
-    bootstrap_path: "/shared/laravel/install"
+    framework_path: "/shared/laravel/install"
 ```
 
 You can specify either an absolute path (use leading slash), or a path relative
@@ -125,7 +125,7 @@ install location would be as follows:
 
 ```yaml
 laravel_extension:
-    bootstrap_path: ".." # Read like vendor/../
+    framework_path: ".." # Read like vendor/../
 ```
 
 ##Usage

--- a/src/PhpSpec/Laravel/Extension/LaravelExtension.php
+++ b/src/PhpSpec/Laravel/Extension/LaravelExtension.php
@@ -53,7 +53,7 @@ class LaravelExtension implements ExtensionInterface {
                 $config = $c->getParam('laravel_extension');
 
                 $bootstrapPath = $getBoostrapPath(
-                    isset($config['bootstrap_path']) ? $config['bootstrap_path'] : null
+                    isset($config['framework_path']) ? $config['framework_path'] : null
                 );
 
                 if (file_exists($bootstrapPath . '/autoload.php')) {


### PR DESCRIPTION
This PR adds the functionality to manually set the path to the Laravel framework via config in `phpspec.yml`, as follows:

``` yaml
laravel_extension:
    framework_path: "/shared/laravel/install"
```
