### PR TITLE
PhpSpec 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,15 @@ php:
   - 7.0
   - 7.1
 
-env:
-  - LARAVEL_VERSION=5.1.*
-  - LARAVEL_VERSION=5.2.*
-  - LARAVEL_VERSION=5.3.*
-  - LARAVEL_VERSION=5.4.*
-
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - travis_retry composer require --no-update "laravel/framework:${LARAVEL_VERSION}"
 
 install:
-  - travis_retry composer update --prefer-stable --no-interaction --no-suggest
+  - composer update
 
 script:
   - ./bin/phpspec run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 
@@ -17,7 +16,6 @@ cache:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - travis_retry composer require --no-update "phpspec/phpspec:~3.0"
   - travis_retry composer require --no-update "laravel/framework:${LARAVEL_VERSION}"
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^5.6 || ^7.0",
-    "phpspec/phpspec": "~3.0",
+    "php": "^7.0",
+    "phpspec/phpspec": "^4.0",
     "laravel/framework": "~5.1"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.0",
     "phpspec/phpspec": "^4.0",
-    "laravel/framework": "~5.1"
+    "laravel/framework": "^5.4"
   },
   "autoload": {
     "psr-0": {

--- a/spec/PhpSpec/Laravel/Extension/LaravelExtensionSpec.php
+++ b/spec/PhpSpec/Laravel/Extension/LaravelExtensionSpec.php
@@ -54,7 +54,7 @@ class LaravelExtensionSpec extends ObjectBehavior
         $this->load($container, []);
     }
 
-    public function getMatchers()
+    public function getMatchers() : array
     {
         return [
             'endWith' => function($subject, $value) {

--- a/src/PhpSpec/Laravel/Runner/Maintainer/LaravelMaintainer.php
+++ b/src/PhpSpec/Laravel/Runner/Maintainer/LaravelMaintainer.php
@@ -40,7 +40,7 @@ class LaravelMaintainer implements Maintainer
      * @param \PhpSpec\Loader\Node\ExampleNode $example
      * @return boolean
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example) : bool
     {
         return $example->getSpecification()->getClassReflection()->hasMethod('setLaravel');
     }
@@ -75,7 +75,7 @@ class LaravelMaintainer implements Maintainer
      *
      * @return int
      */
-    public function getPriority()
+    public function getPriority() : int
     {
         return 1000;
     }

--- a/src/PhpSpec/Laravel/Runner/Maintainer/PresenterMaintainer.php
+++ b/src/PhpSpec/Laravel/Runner/Maintainer/PresenterMaintainer.php
@@ -37,7 +37,7 @@ class PresenterMaintainer implements Maintainer
      * @param \PhpSpec\Loader\Node\ExampleNode $example
      * @return boolean
      */
-    public function supports(ExampleNode $example)
+    public function supports(ExampleNode $example) : bool
     {
         return $example->getSpecification()->getClassReflection()->hasMethod('setPresenter');
     }
@@ -71,7 +71,7 @@ class PresenterMaintainer implements Maintainer
      *
      * @return int
      */
-    public function getPriority()
+    public function getPriority() : int
     {
         return 1000;
     }


### PR DESCRIPTION
Provides a version which works with PhpSpec 4, released recently.

Removes builds testing in PHP 5, as this is no longer supported by PhpSpec.

Removes builds testing in older versions of Laravel, as they are pinned to old `3.0.*` versions of Symfony components.  This means you cannot install PhpSpec 4 with Laravel < 5.4.