### PR TITLE
Feature/add support for custom env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ extensions:
 
 in your `phpspec.yml`.
 
+### Environment file
+
+You may also want to bootstrap laravel with a custom `.env` file. You can do this by setting:
+```yaml
+extensions:
+  PhpSpec\Laravel\Extension\LaravelExtension:
+    testing_environment_file: ".phpspec.env"
+```
+
+in your `phpspec.yml`.
+
+> Please note that `APP_ENV` set in your custom `.env` file will override the `testing_environment` setting.
+
 ### App bootstrap path
 
 By default, the extension will bootstrap your app by looking for `bootstrap/app.php`

--- a/example.phpspec.yml
+++ b/example.phpspec.yml
@@ -8,5 +8,7 @@ suites:
 extensions:
   PhpSpec\Laravel\Extension\LaravelExtension:
     testing_environment: "testing"
+    # OR
+    testing_environment_file: ".phpspec.env"
 
 formatter.name: pretty

--- a/spec/PhpSpec/Laravel/Util/LaravelSpec.php
+++ b/spec/PhpSpec/Laravel/Util/LaravelSpec.php
@@ -17,13 +17,19 @@ class LaravelSpec extends ObjectBehavior
 
     function it_boots_in_the_testing_env_by_default()
     {
-        $this->beConstructedWith(null, '.');
+        $this->beConstructedWith(null, '.', null);
         $this->getEnv()->shouldBe('testing');
     }
 
     function it_allows_the_env_to_be_set_to_anything()
     {
-        $this->beConstructedWith('whatever', '.');
+        $this->beConstructedWith('whatever', '.', null);
         $this->getEnv()->shouldBe('whatever');
+    }
+
+    function it_allows_the_env_file_to_be_set()
+    {
+        $this->beConstructedWith(null, '.', '.phpspec.env');
+        $this->getEnvFile()->shouldBe('.phpspec.env');
     }
 }

--- a/src/PhpSpec/Laravel/Extension/LaravelExtension.php
+++ b/src/PhpSpec/Laravel/Extension/LaravelExtension.php
@@ -25,7 +25,8 @@ class LaravelExtension implements Extension
         $container->define('laravel', function () use ($params) {
             return new Laravel(
                 isset($params['testing_environment']) ? $params['testing_environment'] : null,
-                $this->getBootstrapPath(isset($params['framework_path']) ? $params['framework_path'] : null)
+                $this->getBootstrapPath(isset($params['framework_path']) ? $params['framework_path'] : null),
+                isset($params['testing_environment_file']) ? $params['testing_environment_file'] : null
             );
         });
 

--- a/src/PhpSpec/Laravel/Util/Laravel.php
+++ b/src/PhpSpec/Laravel/Util/Laravel.php
@@ -33,15 +33,24 @@ class Laravel
     protected $appPath;
 
     /**
+     * Path to the custom .env file.
+     *
+     * @var string
+     */
+    protected $envFile;
+
+    /**
      * Constructor.
      *
      * @param string $env Laravel testing environment. 'testing' by default
      * @param string $appPath Path to the Laravel bootstrap dir
+     * @param string $envPath Path to the custom .env file
      */
-    public function __construct($env, $appPath)
+    public function __construct($env, $appPath, $envPath)
     {
         $this->env = $env ?: 'testing';
         $this->appPath = $appPath;
+        $this->envFile = $envPath;
     }
 
     /**
@@ -75,6 +84,11 @@ class Laravel
         return $this->appPath;
     }
 
+    public function getEnvFile()
+    {
+        return $this->envFile;
+    }
+
     /**
      * Creates a Laravel application.
      *
@@ -82,11 +96,15 @@ class Laravel
      */
     protected function createApplication()
     {
-        putenv('APP_ENV=' . $this->getEnv());
-
         $app = require $this->appPath;
 
-        $app->make(Kernel::class)->bootstrap();
+        if ($this->getEnvFile()) {
+            $app->loadEnvironmentFrom($this->getEnvFile());
+        } else {
+            putenv('APP_ENV=' . $this->getEnv());
+        }
+
+        $app->make(Kernel::class)->bootstrap();;
 
         Carbon::setTestNow(Carbon::now());
 


### PR DESCRIPTION
Added a feature to use custom `.env` files.
It is done via phpspec configuration with `testing_environment_file` setting.
The `testing_environment_file` will override the `testing_environment` setting.

Purpose:
* You can have a dummy env file without any credentials commited to the repo and used for spec testing,
* You can specify a different database connection in that env file that, for example, uses SQLite in memory database.

If you have any suggestions please feel free to message me as I'm more than happy to improve this. Thanks.